### PR TITLE
customer-queue-refactor

### DIFF
--- a/scenes/customer_panel/customer_panel.tscn
+++ b/scenes/customer_panel/customer_panel.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=35 format=3 uid="uid://dxtsd31kpgpvb"]
+[gd_scene load_steps=34 format=3 uid="uid://dxtsd31kpgpvb"]
 
 [ext_resource type="Texture2D" uid="uid://cwhb32383si0o" path="res://assets/images/customer panel/Background.png" id="1_14pq6"]
-[ext_resource type="PackedScene" uid="uid://dbplx5axo07pj" path="res://scenes/customer_panel/doll.tscn" id="2_aajm0"]
 [ext_resource type="Texture2D" uid="uid://f46riariqn3d" path="res://assets/images/customer panel/Counter (positioned for 100x180).png" id="3_hf0r0"]
 [ext_resource type="Texture2D" uid="uid://dgjhj680dtatb" path="res://assets/images/customer panel/Shelf (positioned for 100x180).png" id="4_pfvda"]
 [ext_resource type="Texture2D" uid="uid://bpwjb63grcivj" path="res://assets/images/customer panel/Leaves  (positioned for 100x180).png" id="5_0ijvf"]
@@ -117,12 +116,6 @@ scale = Vector2(6, 6)
 z_index = 1
 texture = ExtResource("1_14pq6")
 centered = false
-
-[node name="Doll" parent="Panel" instance=ExtResource("2_aajm0")]
-unique_name_in_owner = true
-z_index = 2
-z_as_relative = false
-position = Vector2(52, 90)
 
 [node name="BackgroundElements" type="Node2D" parent="Panel"]
 z_index = 2

--- a/scenes/customer_panel/customer_panel.tscn
+++ b/scenes/customer_panel/customer_panel.tscn
@@ -215,6 +215,7 @@ z_index = 1
 script = ExtResource("9_vxukn")
 
 [node name="Sprite2D" type="Sprite2D" parent="Panel/PatienceMeter"]
+visible = false
 position = Vector2(78.4483, 98.4483)
 texture = ExtResource("9_w44ji")
 hframes = 3

--- a/scenes/customer_panel/doll.tscn
+++ b/scenes/customer_panel/doll.tscn
@@ -61,7 +61,7 @@ _data = {
 }
 
 [node name="Doll" type="Node2D"]
-z_index = 1
+z_index = 2
 z_as_relative = false
 texture_filter = 1
 position = Vector2(-22, -90)

--- a/scenes/customer_panel/doll.tscn
+++ b/scenes/customer_panel/doll.tscn
@@ -61,7 +61,10 @@ _data = {
 }
 
 [node name="Doll" type="Node2D"]
+z_index = 1
+z_as_relative = false
 texture_filter = 1
+position = Vector2(-22, -90)
 script = ExtResource("1_mqid1")
 
 [node name="body" type="Sprite2D" parent="."]

--- a/scripts/customer_panel/counter.gd
+++ b/scripts/customer_panel/counter.gd
@@ -24,7 +24,7 @@ func _check_recipe():
 			mugObject = child
 			ingredients = child.get_ingredients()
 			
-	var drink = customer_panel.get_doll().get_customer().drink
+	var drink = customer_panel.get_node('./Panel/Doll').get_customer().drink
 	print("Created drink:", drink.name)
 
 	var is_correct = drink.isValidIngredients(ingredients)

--- a/scripts/customer_panel/counter.gd
+++ b/scripts/customer_panel/counter.gd
@@ -10,9 +10,12 @@ var entered = true
 func _ready() -> void:
 	modulate = Color(Color.MEDIUM_PURPLE, 0.7)
 	mugObject = levelManager.get_node('KitchenPanel').get_node("Mug")
-	print(mugObject)
 	var area2d = counter.get_node("Area2D")
 
+func get_queue_customer():
+	for child in customer_panel.get_node('Panel').get_children():
+		if child.name.begins_with("Doll"):
+			return child
 ## @brief Compares the ingredients in the mug with the correct recipe, and determines whether the drink is correct.
 ## @details This function is called when the mug is placed on the counter. It checks the drink ingredients and notifies the customer manager.
 func _check_recipe():
@@ -24,7 +27,8 @@ func _check_recipe():
 			mugObject = child
 			ingredients = child.get_ingredients()
 			
-	var drink = customer_panel.get_node('./Panel/Doll').get_customer().drink
+	var customer = get_queue_customer()		
+	var drink = customer.get_customer().drink
 	print("Created drink:", drink.name)
 
 	var is_correct = drink.isValidIngredients(ingredients)

--- a/scripts/customer_panel/customer_queue_manager.gd
+++ b/scripts/customer_panel/customer_queue_manager.gd
@@ -35,7 +35,6 @@ func is_customer_ready():
 	
 func _ready():
 	customer_ready = false
-	doll = get_parent().get_node('Doll')
 	queue_numbers = GameManager.get_level_queue(1)
 	var vip_named_count = 0
 	for i in range(0,queue_numbers[0]):
@@ -80,6 +79,7 @@ func spawn_next_customer():
 		queue_empty = true
 	
 	strikes = 0
+	await respawn_doll()
 	doll.reset_pos()
 	var next = customer_queue.pop_front()
 	doll.customer = next 
@@ -111,6 +111,7 @@ func remove_customer():
 	%DialogueLabel.visible = false
 	await doll.exit_queue()
 	customer = null
+	doll.queue_free()
 	spawn_next_customer()
 	
 func react_to_drink(correct: bool):
@@ -131,3 +132,13 @@ func react_to_drink(correct: bool):
 		%DialogueLabel.text = line
 		strikes += 1
 		await get_tree().create_timer(1.5).timeout
+
+func respawn_doll():
+	var doll_scene = load("res://scenes/customer_panel/doll.tscn") 
+	var new_doll = doll_scene.instantiate()
+	get_parent().call_deferred("add_child", new_doll)
+	move_child(new_doll, 0)
+	new_doll.name = "Doll"
+	await new_doll.doll_ready
+	doll = new_doll
+	

--- a/scripts/customer_panel/customer_queue_manager.gd
+++ b/scripts/customer_panel/customer_queue_manager.gd
@@ -16,15 +16,14 @@ extends Node2D
 @export var possible_second_incorrect_drink_lines: Array[String]
 @export var possible_third_incorrect_drink_lines: Array[String]
 @export var possible_order_lines: Array[String]
+@export var drinks: Array[Resource]
 
 var customer_queue: Array = []
 var queue_numbers
 var customer_ready
-var strikes = 0
 var queue_empty = false
 var doll
-
-@export var drinks: Array[Resource]
+var strikes = 0
 
 #  Function to pick a random drink
 func get_random_drink() -> Drink:
@@ -77,7 +76,6 @@ func is_queue_empty():
 func spawn_next_customer():
 	if customer_queue.is_empty():
 		queue_empty = true
-	
 	strikes = 0
 	await respawn_doll()
 	doll.reset_pos()
@@ -137,8 +135,8 @@ func respawn_doll():
 	var doll_scene = load("res://scenes/customer_panel/doll.tscn") 
 	var new_doll = doll_scene.instantiate()
 	get_parent().call_deferred("add_child", new_doll)
-	move_child(new_doll, 0)
-	new_doll.name = "Doll"
 	await new_doll.doll_ready
+	new_doll.name = "Doll"
+	get_parent().move_child(new_doll, 0)
 	doll = new_doll
 	

--- a/scripts/customer_panel/doll.gd
+++ b/scripts/customer_panel/doll.gd
@@ -5,13 +5,16 @@ var old_position
 var new_position
 var leaving_queue = false
 var end_position 
-var reset_position
+var reset_position = Vector2(-22,90)
 signal movement_finished
+signal doll_ready
 var finished_moving =  false
 var order_line
+@onready var dialogue_box = get_node("../DialogueBox/DialogueLabel")
 
 func _ready() -> void:
-	reset_position = Vector2(-22,90)
+	await get_tree().process_frame
+	emit_signal('doll_ready')
 	
 func reset_pos():
 	self.position = reset_position
@@ -26,7 +29,7 @@ func enter_animation():
 	await tween.finished
 	
 func exit_animation():
-	var tween = get_tree().create_tween()
+	var tween = create_tween()
 	old_position = self.position
 	new_position = Vector2(old_position.x+10, old_position.y+2)
 	end_position = Vector2(old_position.x+20, old_position.y)
@@ -75,7 +78,7 @@ func say_dialogue():
 	old_position = self.position
 	if customer.idle_body_texture == null:
 		new_position = Vector2(old_position.x, old_position.y +2)
-		%DialogueLabel.text = order_line
+		dialogue_box.text = order_line
 		while not leaving_queue:
 			await NPC_animation()
 		emit_signal("movement_finished")
@@ -113,7 +116,7 @@ func say_dialogue():
 		emit_signal("movement_finished")
 		
 func repeat_order_line():
-	%DialogueLabel.text = order_line
+	dialogue_box.text = order_line
 
 func get_dialogue_time(line):
 	var time = 0
@@ -126,7 +129,7 @@ func get_dialogue_time(line):
 func say_special_dialogue():
 	for line in customer.special_order_lines:
 		var time = get_dialogue_time(line)
-		%DialogueLabel.text = line
+		dialogue_box.text = line
 		await get_tree().create_timer(time).timeout
 		
 func enter_queue():

--- a/scripts/general/game_manager.gd
+++ b/scripts/general/game_manager.gd
@@ -4,7 +4,7 @@ var total_money = 0
 var upgrades = [['Grinder',0,1]] 
 var shop_upgrade_dictionary = {'A': "grinder", 'B': "coffee_machine"} #Changed naming to work better with scene finding
 var level_upgrade_dictionary = {1: ['A']}
-var level_queue = [[6,1,1]]
+var level_queue = [[1,0,0]]
 var is_dragging = false
 
 func get_level_upgrades(level_number):


### PR DESCRIPTION
Updated the queue to hopefully stop the rubberbanding issue that was occurring with the use of one customer object being repositioned. Now everytime the customer leaves the screen, the object is deleted and a new one is created.
[https://trello.com/c/Oiy1GSfQ](url)